### PR TITLE
fix: path separator in the map of components

### DIFF
--- a/src/server/ProgramService.ts
+++ b/src/server/ProgramService.ts
@@ -64,14 +64,15 @@ export class ProgramService {
      */
     private async createComponentsMap() {
         const componentMap = new Map<string, string>();
-        // fix directory path with correct separator (it needs to be '/' for JS imports)
-        const currentDirectory = this.program.getCurrentDirectory().split(path.sep).join('/');
+        const currentDirectory = this.program.getCurrentDirectory();
         const visit = (node: Node) => {
             if (ts.isClassDeclaration(node)) {
                 let fileName = node.getSourceFile().fileName;
                 if (!path.isAbsolute(fileName)) {
                     fileName = path.join(currentDirectory, fileName);
                 }
+                // fix path with correct separator (it needs to be '/' for JS imports)
+                fileName = fileName.split(path.sep).join('/');
 
                 /**
                  * Add tagName to classDoc, extracted from `@Component({tag: 'foo-bar'})` decorator

--- a/src/server/stencil-loader.ts
+++ b/src/server/stencil-loader.ts
@@ -36,7 +36,11 @@ async function stencilLoader(source: string) {
   const sourceFile = programService.getSourceFile(fileName);
   const declaration = generateCustomElementDeclaration(data[0], sourceFile);
 
-  callback(null, `${htmlTagNames.filter((tagName: string) => components.has(tagName)).map((tagName: string) => `import '${components.get(tagName)}';`).join('\n')}
+  callback(null, `${
+    htmlTagNames.filter((tagName: string) => components.has(tagName))
+      .map((tagName: string) => `import '${components.get(tagName)}';`)
+      .join('\n')
+  }
 import { setCustomElementsManifest, getCustomElements } from '@storybook/web-components';
 ${code}
 


### PR DESCRIPTION
Fix path separator to be JS compliant when generating components' map.