### PR TITLE
Change `yarn install` to `yarn add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install and register the addon in your Storybook:
 
 ```
 npm install storybook-addon-stencil -D
-yarn install storybook-addon-stencil -D
+yarn add storybook-addon-stencil -D
 ```
 
 **.storybook/main.js**


### PR DESCRIPTION
It otherwises fails with the following error 

```
error `install` has been replaced with `add` to add new dependencies. Run "yarn add storybook-addon-stencil --dev" instead.
```